### PR TITLE
[16.0] sale_channel_search_engine: contextualize

### DIFF
--- a/sale_channel_search_engine/models/__init__.py
+++ b/sale_channel_search_engine/models/__init__.py
@@ -1,2 +1,4 @@
 from . import sale_channel_indexable_record
 from . import sale_channel
+from . import se_binding
+from . import se_backend

--- a/sale_channel_search_engine/models/sale_channel.py
+++ b/sale_channel_search_engine/models/sale_channel.py
@@ -8,4 +8,8 @@ from odoo import fields, models
 class SaleChannel(models.Model):
     _inherit = "sale.channel"
 
+    _sql_constraints = [
+        ("se_uniq", "unique (search_engine_id)", "Only one backend per search engine")
+    ]
+
     search_engine_id = fields.Many2one("se.backend", "Search Engine")

--- a/sale_channel_search_engine/models/se_backend.py
+++ b/sale_channel_search_engine/models/se_backend.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Raphaël Reverdy<raphael.reverdy@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo import fields, models
+
+
+class SeBackend(models.Model):
+    _inherit = "se.backend"
+
+    sale_channel_id = fields.One2many(
+        # is a one2one relation
+        comodel_name="sale.channel",
+        inverse_name="search_engine_id",
+    )

--- a/sale_channel_search_engine/models/se_binding.py
+++ b/sale_channel_search_engine/models/se_binding.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Raphaël Reverdy<raphael.reverdy@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SeBinding(models.Model):
+    _inherit = "se.binding"
+
+    channel_id = fields.Many2one("sale.channel", compute="_compute_sale_channel")
+
+    def _compute_sale_channel(self):
+        for rec in self:
+            rec.channel_id = rec.backend_id.sale_channel_id
+
+    def _contextualize(self, record):
+        res = super()._contextualize(record)
+        return res.with_context(channel_id=res.channel_id.id)

--- a/sale_channel_search_engine/readme/CONTRIBUTORS.rst
+++ b/sale_channel_search_engine/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Sébastien Beau <sebastien.beau@akretion.com>
+* Raphaël Reverdy <raphael.reverdy@akretion.com>


### PR DESCRIPTION
inject sale_channel into the context during the recompute of the binding having the sale_channel is important for example to filter out the categories not published

- [ ] https://github.com/OCA/search-engine/pull/155