### PR TITLE
16.0 sync root categ

### DIFF
--- a/sale_channel_category/__manifest__.py
+++ b/sale_channel_category/__manifest__.py
@@ -21,6 +21,7 @@
     ],
     "data": [
         "views/product_category_view.xml",
+        "views/sale_channel_view.xml",
     ],
     "demo": [],
 }

--- a/sale_channel_category/models/__init__.py
+++ b/sale_channel_category/models/__init__.py
@@ -1,1 +1,2 @@
 from . import product_category
+from . import sale_channel

--- a/sale_channel_category/models/product_category.py
+++ b/sale_channel_category/models/product_category.py
@@ -2,9 +2,25 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, fields, models
 
 
 class ProductCategory(models.Model):
     _inherit = ["product.category", "sale.channel.owner"]
     _name = "product.category"
+
+    channel_ids = fields.Many2many(
+        "sale.channel",
+        string="Sale Channel",
+        store=True,
+        compute="_compute_channel_ids",
+        readonly=False,
+        recursive=True,
+    )
+
+    @api.depends("parent_id.channel_ids")
+    def _compute_channel_ids(self):
+        for record in self:
+            if record.parent_id:
+                record.channel_ids = record.parent_id.channel_ids
+                record._on_sale_channel_modified()

--- a/sale_channel_category/models/sale_channel.py
+++ b/sale_channel_category/models/sale_channel.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo import api, fields, models
+
+
+class SaleChannel(models.Model):
+    _inherit = "sale.channel"
+
+    root_categ_ids = fields.Many2many(
+        comodel_name="product.category",
+        string="Root Categ",
+        domain=[("parent_id", "=", False)],
+    )
+
+    def write(self, vals):
+        if "root_categ_ids" in vals:
+            root_categs = self.root_categ_ids
+        res = super().write(vals)
+        if "root_categ_ids" in vals:
+            # Notify manually root categ (the computed field will notify the child)
+            (root_categs | self.root_categ_ids)._on_sale_channel_modified()
+        return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        # Notify manually root categ (the computed field will notify the child)
+        records.root_categ_ids._on_sale_channel_modified()
+        return records

--- a/sale_channel_category/views/product_category_view.xml
+++ b/sale_channel_category/views/product_category_view.xml
@@ -6,7 +6,11 @@
         <field name="inherit_id" ref="product.product_category_form_view" />
         <field name="arch" type="xml">
             <field name="parent_id" position="after">
-                <field name="channel_ids" widget="many2many_tags" />
+                <field
+                    name="channel_ids"
+                    widget="many2many_tags"
+                    attrs="{'readonly': [('parent_id', '!=', False)]}"
+                />
             </field>
         </field>
     </record>

--- a/sale_channel_category/views/sale_channel_view.xml
+++ b/sale_channel_category/views/sale_channel_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="sale_channel_view_form" model="ir.ui.view">
+        <field name="model">sale.channel</field>
+        <field name="inherit_id" ref="sale_channel.sale_channel_view_form" />
+        <field name="arch" type="xml">
+            <field name="active" position="after">
+                <field name="root_categ_ids" widget="many2many_tags" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_channel_search_engine_category/tests/__init__.py
+++ b/sale_channel_search_engine_category/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_channel

--- a/sale_channel_search_engine_category/tests/test_channel.py
+++ b/sale_channel_search_engine_category/tests/test_channel.py
@@ -1,0 +1,151 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from uuid import uuid4
+
+from odoo.fields import Command
+
+from odoo.addons.connector_search_engine.tests.test_all import TestBindingIndexBase
+
+
+class TestChannel(TestBindingIndexBase):
+    @classmethod
+    def _create_sale_channel_with_search_engine(cls, name):
+        search_engine = cls.env["se.backend"].create(
+            {
+                "name": "Fake SE",
+                "tech_name": uuid4(),
+                "backend_type": "fake",
+                "index_ids": [
+                    Command.create(
+                        {
+                            "name": "Categ Index",
+                            "model_id": cls.env["ir.model"]
+                            .search([("model", "=", "product.category")], limit=1)
+                            .id,
+                            "lang_id": cls.env.ref("base.lang_en").id,
+                            "serializer_type": "fake",
+                        }
+                    )
+                ],
+            }
+        )
+        return cls.env["sale.channel"].create(
+            {
+                "name": name,
+                "search_engine_id": search_engine.id,
+            }
+        )
+
+    @classmethod
+    def create_categ(cls, name, parent=None, channels=None):
+        vals = {"name": name}
+        if parent:
+            vals["parent_id"] = parent.id
+        if channels:
+            vals["channel_ids"] = channels.ids
+        return cls.env["product.category"].create(vals)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.channel_1 = cls._create_sale_channel_with_search_engine("Channel 1")
+        cls.channel_2 = cls._create_sale_channel_with_search_engine("Channel 2")
+        cls.channels = cls.channel_1 + cls.channel_2
+
+        cls.categ_root = cls.create_categ("Root", channels=cls.channels)
+        cls.categ_level_1 = cls.create_categ("Level 1", cls.categ_root)
+        cls.categ_level_2 = cls.create_categ("Level 2", cls.categ_level_1)
+
+    def test_create_categ(self):
+        self.assertEqual(self.categ_level_1.channel_ids, self.channels)
+        self.assertEqual(self.categ_level_2.channel_ids, self.channels)
+        self.assertEqual(len(self.categ_level_1._get_bindings()), 2)
+        self.assertEqual(len(self.categ_level_2._get_bindings()), 2)
+
+    def test_add_parent(self):
+        categ = self.create_categ("Root -1", channels=self.channel_1)
+        self.categ_root.parent_id = categ
+        self.assertEqual(self.categ_root.channel_ids, self.channel_1)
+        self.assertEqual(self.categ_level_1.channel_ids, self.channel_1)
+        self.assertEqual(self.categ_level_2.channel_ids, self.channel_1)
+        for categ in [self.categ_root, self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 2)
+            self.assertEqual(
+                set(bindings.mapped("state")), {"to_recompute", "to_delete"}
+            )
+
+    def test_remove_parent(self):
+        self.categ_level_1.parent_id = None
+        self.assertEqual(self.categ_level_1.channel_ids, self.channels)
+        self.assertEqual(self.categ_level_2.channel_ids, self.channels)
+
+    def test_change_parent(self):
+        categ = self.create_categ("Root 2", channels=self.channel_1)
+        self.categ_level_1.parent_id = categ
+        self.assertEqual(self.categ_level_1.channel_ids, self.channel_1)
+        self.assertEqual(self.categ_level_2.channel_ids, self.channel_1)
+        for categ in [self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 2)
+            self.assertEqual(
+                set(bindings.mapped("state")), {"to_recompute", "to_delete"}
+            )
+
+    def test_parent_remove_channel(self):
+        self.categ_root.channel_ids = None
+        self.assertFalse(self.categ_level_1.channel_ids)
+        self.assertFalse(self.categ_level_2.channel_ids)
+        for categ in [self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 2)
+            self.assertEqual(set(bindings.mapped("state")), {"to_delete"})
+
+    def test_parent_set_channel(self):
+        # First remove
+        self.categ_root.channel_ids = None
+        # Set a channel
+        self.categ_root.channel_ids = self.channel_1
+        self.assertEqual(self.categ_level_1.channel_ids, self.channel_1)
+        self.assertEqual(self.categ_level_2.channel_ids, self.channel_1)
+        for categ in [self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 2)
+            self.assertEqual(
+                set(bindings.mapped("state")), {"to_recompute", "to_delete"}
+            )
+
+    def test_parent_change_channel(self):
+        self.categ_root.channel_ids = self.channel_1
+        self.assertEqual(self.categ_level_1.channel_ids, self.channel_1)
+        self.assertEqual(self.categ_level_2.channel_ids, self.channel_1)
+        for categ in [self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 2)
+            self.assertEqual(
+                set(bindings.mapped("state")), {"to_recompute", "to_delete"}
+            )
+
+    def test_add_from_channel(self):
+        channel_3 = self._create_sale_channel_with_search_engine("Channel 3")
+        channel_3.root_categ_ids = self.categ_root
+        self.assertEqual(self.categ_root.channel_ids, self.channels | channel_3)
+        self.assertEqual(self.categ_level_1.channel_ids, self.channels | channel_3)
+        self.assertEqual(self.categ_level_2.channel_ids, self.channels | channel_3)
+        for categ in [self.categ_root, self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 3)
+            self.assertEqual(set(bindings.mapped("state")), {"to_recompute"})
+
+    def test_remove_from_channel(self):
+        self.channel_2.root_categ_ids = None
+        self.assertEqual(self.categ_level_1.channel_ids, self.channel_1)
+        self.assertEqual(self.categ_level_2.channel_ids, self.channel_1)
+        for categ in [self.categ_root, self.categ_level_1, self.categ_level_2]:
+            bindings = categ._get_bindings()
+            self.assertEqual(len(bindings), 2)
+            self.assertEqual(
+                set(bindings.mapped("state")), {"to_recompute", "to_delete"}
+            )


### PR DESCRIPTION
@hparfr to discuss together

Alternative implementation of "configuring the categ on the root level". https://github.com/OCA/sale-channel/pull/8

With this PR you can
- add/remove a channel on a root categ
- add/remove root categ on channel
=> all the binding are automatically created or set to be deleted

For this I only add a computed field on categ (to propagate the channel_ids on the children), and add a notification on the root categ in case of change on the sale.channel
