### PR TITLE
sale_channel_search_engine: add synchronize button

### DIFF
--- a/sale_channel_search_engine/models/sale_channel.py
+++ b/sale_channel_search_engine/models/sale_channel.py
@@ -16,3 +16,10 @@ class SaleChannel(models.Model):
 
         action["domain"] = [("index_id", "in", indexes)]
         return action
+
+    def synchronize_channel_index_action(self):
+        self._synchronize_channel_index()
+        return self.open_se_binding()
+
+    def _synchronize_channel_index(self):
+        pass

--- a/sale_channel_search_engine/views/sale_channel_view.xml
+++ b/sale_channel_search_engine/views/sale_channel_view.xml
@@ -22,4 +22,11 @@
             </group>
         </field>
     </record>
+    <record id="action_synchronize_channel_index" model="ir.actions.server">
+        <field name="name">Synchronize</field>
+        <field name="model_id" ref="sale_channel.model_sale_channel" />
+        <field name="binding_model_id" ref="sale_channel.model_sale_channel" />
+        <field name="state">code</field>
+        <field name="code">action = record.synchronize_channel_index_action()</field>
+    </record>
 </odoo>


### PR DESCRIPTION
add a synchronize feature on sale_channel
its aim is to trigger the (re)compute of all the
related records (bindings)